### PR TITLE
Fix breadcrumb wrapping in content editor footer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
@@ -103,6 +103,34 @@ export class UmbWorkspaceBreadcrumbElement extends UmbLitElement {
 		css`
 			:host {
 				margin-left: var(--uui-size-layout-1);
+				overflow-y: auto;
+				max-height: calc(var(--umb-footer-layout-height, 70px) - 20px);
+				padding: 10px 0;
+			}
+
+			/* Enable wrapping for the breadcrumbs container */
+			uui-breadcrumbs {
+				flex-wrap: wrap !important;
+				row-gap: 5px;
+				align-items: flex-start;
+			}
+
+			/* Remove max-width constraint on breadcrumb items to prevent truncation */
+			uui-breadcrumbs::part(breadcrumbs-list) {
+				flex-wrap: wrap !important;
+				row-gap: 5px;
+			}
+
+			/* Override the breadcrumb item's max-width to show full text */
+			uui-breadcrumb-item {
+				max-width: none !important;
+			}
+
+			/* Ensure proper styling for wrapped items */
+			uui-breadcrumb-item #link,
+			uui-breadcrumb-item #last-item {
+				max-width: none !important;
+				white-space: normal;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
@@ -137,11 +137,35 @@ export class UmbWorkspaceVariantMenuBreadcrumbElement extends UmbLitElement {
 		UmbTextStyles,
 		css`
 			:host {
-				/* TODO: This is a temp solution to handle an issue where long nested breadcrumbs would hide workspace actions */
-				overflow: hidden;
-				display: flex;
-				flex-direction: row-reverse;
 				margin-left: var(--uui-size-layout-1);
+				overflow-y: auto;
+				max-height: calc(var(--umb-footer-layout-height, 70px) - 20px);
+				padding: 10px 0;
+			}
+
+			/* Enable wrapping for the breadcrumbs container */
+			uui-breadcrumbs {
+				flex-wrap: wrap !important;
+				row-gap: 5px;
+				align-items: flex-start;
+			}
+
+			/* Remove max-width constraint on breadcrumb items to prevent truncation */
+			uui-breadcrumbs::part(breadcrumbs-list) {
+				flex-wrap: wrap !important;
+				row-gap: 5px;
+			}
+
+			/* Override the breadcrumb item's max-width to show full text */
+			uui-breadcrumb-item {
+				max-width: none !important;
+			}
+
+			/* Ensure proper styling for wrapped items */
+			uui-breadcrumb-item #link,
+			uui-breadcrumb-item #last-item {
+				max-width: none !important;
+				white-space: normal;
 			}
 		`,
 	];


### PR DESCRIPTION
## Summary
- Fixes breadcrumb wrapping regression introduced in v16 where long breadcrumb paths are truncated instead of wrapping
- Restores the v13 behavior for improved editor experience with deeply nested content
- Addresses issue reported in upstream repository: umbraco/Umbraco-CMS#20132

## Changes Made
1. **workspace-menu-breadcrumb.element.ts**
   - Added `flex-wrap: wrap` to enable breadcrumb wrapping
   - Set 5px row gap between wrapped lines
   - Removed max-width constraints on breadcrumb items
   - Added scrolling support within fixed footer height

2. **workspace-variant-menu-breadcrumb.element.ts**
   - Removed temporary workaround (overflow hidden, flex-direction reverse)
   - Applied same wrapping and scrolling improvements
   - Ensured consistency with standard breadcrumb component

## Test Plan
- [x] Build frontend successfully with `npm run build:for:cms`
- [ ] Test with 4-5 level deep content hierarchy with long names
- [ ] Verify breadcrumbs wrap at different screen resolutions
- [ ] Confirm 5px spacing between wrapped rows
- [ ] Check scrolling works when breadcrumbs exceed footer height
- [ ] Test both regular and variant workspaces

## Screenshots
The fix enables breadcrumbs to wrap like in v13, showing the full content path regardless of screen size.

🤖 Generated with [Claude Code](https://claude.ai/code)