### PR TITLE
Fix mandatory field focus hijacking in document editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -378,9 +378,11 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	/**
 	 * Validate this context, all the validators of this context will be validated.
 	 * Notice its a recursive check meaning sub validation contexts also validates their validators.
-	 * @returns succeed {Promise<boolean>} - Returns a promise that resolves to true if the validation succeeded.
+	 * @param {Object} [options] - Optional configuration for validation behavior
+	 * @param {boolean} [options.focusOnError=false] - Whether to focus on first invalid element
+	 * @returns {Promise<void>} Returns a promise that resolves if validation succeeded, rejects if failed.
 	 */
-	async validate(): Promise<void> {
+	async validate(options?: { focusOnError?: boolean }): Promise<void> {
 		this.#validationMode = true;
 
 		const resultsStatus =
@@ -417,8 +419,10 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					notValidValidators,
 				);
 			}
-			// Focus first invalid element:
-			this.focusFirstInvalidElement();
+			// Only focus first invalid element if explicitly requested:
+			if (options?.focusOnError === true) {
+				this.focusFirstInvalidElement();
+			}
 			return Promise.reject();
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
@@ -71,10 +71,11 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 
 	/**
 	 * If a Workspace has multiple validation contexts, then this method can be overwritten to return the correct one.
-	 * @returns Promise that resolves to void when the validation is complete.
+	 * @param {boolean} [focusOnError=false] - Whether to focus on first invalid element (true for submit validation)
+	 * @returns {Promise<Array<void>>} Promise that resolves to void when the validation is complete.
 	 */
-	public async validate(): Promise<Array<void>> {
-		return await Promise.all(this.#validationContexts.map((context) => context.validate()));
+	public async validate(focusOnError = false): Promise<Array<void>> {
+		return await Promise.all(this.#validationContexts.map((context) => context.validate({ focusOnError })));
 	}
 
 	public async requestSubmit(): Promise<void> {
@@ -85,7 +86,8 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 	}
 
 	protected async _validateAndLog(): Promise<void> {
-		await this.validate().catch(async () => {
+		// Focus on error during submit validation
+		await this.validate(true).catch(async () => {
 			// TODO: Implement developer-mode logging here. [NL]
 			console.warn(
 				'Validation failed because of these validation messages still begin present: ',

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
@@ -86,7 +86,7 @@ export class UmbWorkspacePackageBuilderElement extends UmbLitElement {
 
 	async #save() {
 		try {
-			await this.#validationContext.validate();
+			await this.#validationContext.validate({ focusOnError: true });
 			if (!this._package) return;
 
 			this._submitState = 'waiting';
@@ -107,7 +107,7 @@ export class UmbWorkspacePackageBuilderElement extends UmbLitElement {
 
 	async #update() {
 		try {
-			await this.#validationContext.validate();
+			await this.#validationContext.validate({ focusOnError: true });
 			if (!this._package?.unique) return;
 
 			this._submitState = 'waiting';

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-page-field-builder/templating-page-field-builder-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/modals/templating-page-field-builder/templating-page-field-builder-modal.element.ts
@@ -28,7 +28,7 @@ export class UmbTemplatingPageFieldBuilderModalElement extends UmbModalBaseEleme
 		this._submitButtonState = 'waiting';
 
 		try {
-			await this.#validation.validate();
+			await this.#validation.validate({ focusOnError: true });
 			this._submitButtonState = 'success';
 
 			this.value = { output: getUmbracoFieldSnippet(this._field!, this._default, this._recursive) };

--- a/test-focus-fix.md
+++ b/test-focus-fix.md
@@ -1,0 +1,52 @@
+# Focus Management Fix for Mandatory Fields
+
+## Issue Fixed
+The document editor was incorrectly pulling focus back to mandatory fields when users tried to edit other fields like the title, preventing normal editing workflow.
+
+## Root Cause
+The validation controller (`validation.controller.ts`) was automatically calling `focusFirstInvalidElement()` whenever validation failed, including during field navigation when validators were being added or removed.
+
+## Solution Implemented
+
+### 1. Modified Validation Controller
+- Added optional `focusOnError` parameter to the `validate()` method
+- Default is `false` for regular validation, preventing focus hijacking during field navigation
+- Only focuses on invalid elements when explicitly requested
+
+### 2. Updated Submission Contexts
+- Modified `submittable-workspace-context-base.ts` to pass `focusOnError: true` during submit validation
+- Updated package builder and templating modals to pass the option during save/update operations
+
+## Changes Made
+
+### Core Files Modified:
+1. `/src/packages/core/validation/controllers/validation.controller.ts`
+   - Line 385: Added optional `options` parameter to `validate()` method
+   - Line 423: Only calls `focusFirstInvalidElement()` when `options?.focusOnError === true`
+
+2. `/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts`
+   - Line 77-78: Updated `validate()` method to accept and pass `focusOnError` parameter
+   - Line 90: Passes `true` for `focusOnError` during submit validation
+
+3. `/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts`
+   - Updated `#save()` and `#update()` methods to pass `{ focusOnError: true }`
+
+4. `/src/packages/templating/modals/templating-page-field-builder/templating-page-field-builder-modal.element.ts`
+   - Updated `#submit()` method to pass `{ focusOnError: true }`
+
+## Testing Instructions
+
+1. Create a document type with multiple fields, including at least one mandatory field
+2. Create or edit a document of this type
+3. Leave the mandatory field empty
+4. Try to edit the title or other fields
+5. **Expected Result**: You should be able to freely edit any field without focus being pulled back
+6. Try to save/publish the document
+7. **Expected Result**: Focus should jump to the first invalid field and validation messages should appear
+
+## Validation Behavior
+
+- **During editing**: Validation messages appear but focus is not stolen
+- **On save/submit**: Focus jumps to first invalid field if validation fails
+- **Keyboard navigation**: Tab/Shift-Tab work normally without interference
+- **Screen readers**: Validation messages are still announced without focus disruption


### PR DESCRIPTION
## Summary
Fixes the issue where focus is incorrectly pulled back to mandatory fields when users try to edit other fields in the document editor.

## Issue
Resolves #19099 - Focus management problem with mandatory fields preventing normal editing workflow

## Problem
When editing a document with mandatory fields:
- Leaving a mandatory field empty and trying to edit another field (like the title) would cause the focus to jump back to the mandatory field
- This prevented users from freely editing documents before all mandatory fields were filled

## Solution
Modified the validation system to control when focus management should occur:
- Added optional `focusOnError` parameter to validation methods
- Focus only jumps to invalid fields when explicitly requested (during save/submit operations)
- Regular field navigation no longer triggers focus changes

## Changes Made
1. **`validation.controller.ts`**: Added optional `focusOnError` parameter to `validate()` method
2. **`submittable-workspace-context-base.ts`**: Updated to pass `focusOnError: true` during submit validation
3. **`workspace-package-builder.element.ts`**: Updated save/update methods to request focus on errors
4. **`templating-page-field-builder-modal.element.ts`**: Updated submit method to request focus on errors

## Test Plan
1. Create a document type with multiple fields including at least one mandatory field
2. Create/edit a document of this type
3. Leave mandatory field empty
4. Try editing the title or other fields
5. ✅ **Expected**: Can freely edit any field without focus being pulled back
6. Try to save/publish the document  
7. ✅ **Expected**: Focus jumps to first invalid field and validation messages appear

## Validation Behavior
| Action | Validation Messages | Focus Behavior |
|--------|-------------------|----------------|
| Field navigation | ✅ Shown | ❌ No focus stealing |
| Editing fields | ✅ Shown | ❌ No focus stealing |
| Save/Submit | ✅ Shown | ✅ Jumps to first invalid field |

## Checklist
- [x] Code follows existing patterns and conventions
- [x] Changes are properly documented with JSDoc comments
- [x] Frontend builds successfully
- [x] Linting passes
- [x] Validation still prevents saving with empty mandatory fields
- [x] Focus management works correctly on save/submit

🤖 Generated with [Claude Code](https://claude.ai/code)