### PR TITLE
Fix #19099: Prevent focus stealing when editing document with mandatory fields

### DIFF
--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
@@ -85,7 +85,8 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 		}
 	}
 
-	async validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async validate(shouldFocusOnError?: boolean): Promise<void> {
 		// Validate is called when the validation state of this validator is asked to be fully resolved. Like when user clicks Save & Publish.
 		// If you need to ask the server then it could be done here, instead of asking the server each time the value changes.
 		// In this particular example we do not need to do anything, because our validation is represented via a message that we always set no matter the user interaction.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/server-model-validator.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/server-model-validator.context.ts
@@ -118,7 +118,8 @@ export class UmbServerModelValidatorContext extends UmbContextBase implements Um
 	get isValid(): boolean {
 		return this.#isValid;
 	}
-	async validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async validate(shouldFocusOnError?: boolean): Promise<void> {
 		if (this.#validatePromise) {
 			await this.#validatePromise;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/bind-server-validation-to-form-control.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/bind-server-validation-to-form-control.controller.ts
@@ -83,7 +83,8 @@ export class UmbBindServerValidationToFormControl extends UmbControllerBase {
 		this.#control.checkValidity();
 	}
 
-	validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	validate(shouldFocusOnError?: boolean): Promise<void> {
 		//this.#isValid = this.#control.checkValidity();
 		return this.#isValid ? Promise.resolve() : Promise.reject();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/form-control-validator.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/form-control-validator.controller.ts
@@ -60,7 +60,8 @@ export class UmbFormControlValidator extends UmbControllerBase implements UmbVal
 	#setInvalid = this.#setIsValid.bind(this, false);
 	#setValid = this.#setIsValid.bind(this, true);
 
-	validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	validate(shouldFocusOnError?: boolean): Promise<void> {
 		this.#isValid = this.#control.checkValidity();
 		return this.#isValid ? Promise.resolve() : Promise.reject();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -355,7 +355,8 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 		this.#validators.push(validator);
 		//validator.addEventListener('change', this.#onValidatorChange);
 		if (this.#validationMode) {
-			this.validate();
+			// Don't focus when auto-validating on add
+			this.validate(false).catch(() => undefined);
 		}
 	}
 
@@ -368,9 +369,9 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 		if (index !== -1) {
 			// Remove the validator:
 			this.#validators.splice(index, 1);
-			// If we are in validation mode then we should re-validate to focus next invalid element:
+			// If we are in validation mode then we should re-validate but not steal focus:
 			if (this.#validationMode) {
-				this.validate().catch(() => undefined);
+				this.validate(false).catch(() => undefined);
 			}
 		}
 	}
@@ -378,15 +379,16 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	/**
 	 * Validate this context, all the validators of this context will be validated.
 	 * Notice its a recursive check meaning sub validation contexts also validates their validators.
+	 * @param shouldFocusOnError {boolean} - If true, focus will be moved to the first invalid element when validation fails. Defaults to false.
 	 * @returns succeed {Promise<boolean>} - Returns a promise that resolves to true if the validation succeeded.
 	 */
-	async validate(): Promise<void> {
+	async validate(shouldFocusOnError = false): Promise<void> {
 		this.#validationMode = true;
 
 		const resultsStatus =
 			this.#validators.length === 0
 				? true
-				: await Promise.all(this.#validators.map((v) => v.validate())).then(
+				: await Promise.all(this.#validators.map((v) => v.validate(shouldFocusOnError))).then(
 						() => true,
 						() => false,
 					);
@@ -417,8 +419,10 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					notValidValidators,
 				);
 			}
-			// Focus first invalid element:
-			this.focusFirstInvalidElement();
+			// Only focus first invalid element if explicitly requested:
+			if (shouldFocusOnError) {
+				this.focusFirstInvalidElement();
+			}
 			return Promise.reject();
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/value-validator/value-validator.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/value-validator/value-validator.controller.ts
@@ -76,7 +76,8 @@ export class UmbValueValidator<ValueType = unknown> extends UmbControllerBase im
 		}
 	}
 
-	async validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async validate(shouldFocusOnError?: boolean): Promise<void> {
 		this.#validationMode = true;
 		// Validate is called when the validation state of this validator is asked to be fully resolved. Like when user clicks Save & Publish.
 		// If you need to ask the server then it could be done here, instead of asking the server each time the value changes.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/interfaces/validator.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/interfaces/validator.interface.ts
@@ -6,8 +6,9 @@ export interface UmbValidator extends EventTarget {
 
 	/**
 	 * Validate the form, will return a promise that resolves to true if what the Validator represents is valid.
+	 * @param shouldFocusOnError - If true, focus will be moved to the first invalid element when validation fails. Defaults to false.
 	 */
-	validate(): Promise<void>;
+	validate(shouldFocusOnError?: boolean): Promise<void>;
 
 	/**
 	 * Reset the validator to its initial state.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
@@ -71,10 +71,11 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 
 	/**
 	 * If a Workspace has multiple validation contexts, then this method can be overwritten to return the correct one.
+	 * @param shouldFocusOnError - If true, focus will be moved to the first invalid element when validation fails. Defaults to false.
 	 * @returns Promise that resolves to void when the validation is complete.
 	 */
-	public async validate(): Promise<Array<void>> {
-		return await Promise.all(this.#validationContexts.map((context) => context.validate()));
+	public async validate(shouldFocusOnError = false): Promise<Array<void>> {
+		return await Promise.all(this.#validationContexts.map((context) => context.validate(shouldFocusOnError)));
 	}
 
 	public async requestSubmit(): Promise<void> {
@@ -85,7 +86,8 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 	}
 
 	protected async _validateAndLog(): Promise<void> {
-		await this.validate().catch(async () => {
+		// Pass true to focus on error during submit
+		await this.validate(true).catch(async () => {
 			// TODO: Implement developer-mode logging here. [NL]
 			console.warn(
 				'Validation failed because of these validation messages still begin present: ',

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -64,7 +64,8 @@ class UmbLinkPickerValueValidator extends UmbControllerBase implements UmbValida
 		});
 	}
 
-	async validate(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async validate(shouldFocusOnError?: boolean): Promise<void> {
 		this.#isValid = !!this.getValue();
 
 		if (this.#isValid) {


### PR DESCRIPTION
## Summary
- Fixes issue where cursor focus was incorrectly pulled to empty mandatory fields while editing documents
- Users can now freely edit all fields without focus being stolen
- Focus only moves to invalid fields when explicitly submitting the form

## Problem
When editing documents with mandatory fields, the validation system was automatically focusing on the first invalid field during any validation check. This prevented users from editing other fields like the document title, as the cursor would jump back to empty mandatory fields.

## Solution
Modified the validation system to make focus behavior conditional:
- Added optional `shouldFocusOnError` parameter to the `UmbValidator` interface
- Updated `UmbValidationController` to only focus when `shouldFocusOnError=true`
- Modified `UmbSubmittableWorkspaceContextBase` to pass `true` only during submit operations
- Auto-validation (during editing) now passes `false` to prevent focus stealing

## Changes Made
1. **UmbValidator Interface**: Added optional `shouldFocusOnError` parameter to `validate()` method
2. **Validation Controller**: 
   - Only calls `focusFirstInvalidElement()` when `shouldFocusOnError=true`
   - Auto-validation on add/remove validators passes `false`
3. **Submittable Workspace**: Passes `true` during submit to ensure focus on errors when saving
4. **All Validator Implementations**: Updated to support the new parameter signature

## Testing
To test this fix:
1. Create or edit a document with mandatory fields
2. Leave mandatory fields empty
3. Try to edit the document title or other fields
4. Verify that focus is NOT stolen from the field you're editing
5. Click Save & Publish
6. Verify that focus DOES move to the first invalid field

## Related Issue
Fixes #19099

🤖 Generated with [Claude Code](https://claude.ai/code)