### PR TITLE
Fix: Prevent focus stealing when editing documents with mandatory fields

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -168,7 +168,11 @@ export function UmbFormControlMixin<
 				/*if (e.composedPath().some((x) => x === this)) {
 					return;
 				}*/
-				this.checkValidity();
+				// Only set pristine to false to show validation errors visually
+				// Don't call checkValidity() as it may trigger focus changes
+				// The full validation with focus will happen on form submission
+				this.pristine = false;
+				this._runValidators();
 			});
 		}
 


### PR DESCRIPTION
## Summary
Fixes #19099 - Resolves the issue where cursor focus is incorrectly pulled back to mandatory fields when editing other fields in a document.

## Problem
When editing a document with mandatory fields, the cursor focus was being stolen from the field the user was trying to edit (e.g., document title) and forced back to the first invalid mandatory field. This made it impossible to edit other fields until all mandatory fields were filled.

## Solution
Modified the blur event handler in `form-control.mixin.ts` to only show visual validation feedback without triggering focus changes. The key change is:
- **Before**: `blur` event called `checkValidity()` which could trigger `focusFirstInvalidElement()`
- **After**: `blur` event only sets `pristine = false` and runs validators for visual feedback
- Focus management now only occurs during explicit save/submit actions

## Changes
- Modified `src/packages/core/validation/mixins/form-control.mixin.ts`
- Validation errors still appear visually (red borders, error messages)
- Focus only jumps to invalid fields on save/submit attempts
- Backward compatible with existing functionality

## Test plan
1. Create a document with multiple fields where at least one is mandatory
2. Leave the mandatory field empty
3. Try editing the title or other fields - cursor should stay where you click ✅
4. Visual validation feedback should still appear ✅
5. Attempt to save - focus should jump to the first invalid field as expected ✅

## Screenshots/Video
The issue video from the original report shows the problem clearly. After this fix, users can freely navigate between fields without focus being stolen.

🤖 Generated with [Claude Code](https://claude.ai/code)