### PR TITLE
Fix focus jumping to first error field when editing document name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -62,6 +62,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	#validators: Array<UmbValidator> = [];
 	#validationMode: boolean = false;
 	#isValid: boolean = false;
+	#hasFocusedInvalidElement: boolean = false;
 
 	#parent?: UmbValidationController;
 	#sync?: boolean;
@@ -368,8 +369,14 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 		if (index !== -1) {
 			// Remove the validator:
 			this.#validators.splice(index, 1);
-			// If we are in validation mode then we should re-validate to focus next invalid element:
-			if (this.#validationMode) {
+			// Don't re-validate and re-focus if user is actively editing an input field
+			// This prevents focus from jumping away while the user is typing
+			const activeElement = document.activeElement;
+			const isUserEditing = activeElement && 
+				(activeElement.matches('input, textarea, select') || 
+				 activeElement.closest('uui-input, uui-textarea, uui-select'));
+			
+			if (this.#validationMode && !isUserEditing) {
 				this.validate().catch(() => undefined);
 			}
 		}
@@ -382,6 +389,8 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	 */
 	async validate(): Promise<void> {
 		this.#validationMode = true;
+		// Reset the focus flag when validation is explicitly triggered
+		this.#hasFocusedInvalidElement = false;
 
 		const resultsStatus =
 			this.#validators.length === 0
@@ -417,8 +426,11 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 					notValidValidators,
 				);
 			}
-			// Focus first invalid element:
-			this.focusFirstInvalidElement();
+			// Focus first invalid element only once per validation cycle:
+			if (!this.#hasFocusedInvalidElement) {
+				this.focusFirstInvalidElement();
+				this.#hasFocusedInvalidElement = true;
+			}
 			return Promise.reject();
 		}
 
@@ -440,6 +452,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	 */
 	reset(): void {
 		this.#validationMode = false;
+		this.#hasFocusedInvalidElement = false;
 		this.messages.clear();
 		this.#validators.forEach((v) => v.reset());
 	}


### PR DESCRIPTION
## Summary
- Fixes #19099 - Focus keeps jumping to first error field when trying to edit document name
- Prevents focus from repeatedly jumping back to mandatory fields during user input
- Maintains proper validation UX while allowing users to make corrections

## Problem
When validation fails after clicking "Save and Publish", the focus correctly jumps to the first invalid field. However, when users try to edit the document name field (or other fields), the focus keeps jumping back to the first invalid field, preventing users from making changes.

## Solution
Added focus state management to the validation controller to:
1. Track whether focus has already been applied during a validation cycle
2. Prevent re-focusing when users are actively editing input fields
3. Only focus on the first invalid element once per validation attempt

## Changes Made
- Added `#hasFocusedInvalidElement` flag to track focus state
- Modified `validate()` method to only focus once per validation cycle
- Updated `removeValidator()` to check if user is actively editing before re-validating
- Reset focus flag in `reset()` method

## Test Plan
1. Create a document with mandatory fields
2. Leave a mandatory field empty
3. Click "Save and Publish" - verify focus jumps to first invalid field
4. Try to edit the document name - verify you can now type without focus jumping back
5. Test with multiple invalid fields
6. Test with variant selection

## File Changes
- `src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)